### PR TITLE
Fix code scanning alert no. 22: Uncontrolled command line

### DIFF
--- a/WebGoat/App_Code/Util.cs
+++ b/WebGoat/App_Code/Util.cs
@@ -13,6 +13,11 @@ namespace OWASP.WebGoat.NET.App_Code
         
         public static int RunProcessWithInput(string cmd, string args, string input)
         {
+            if (!IsValidArgument(args))
+            {
+                throw new ArgumentException("Invalid arguments provided.");
+            }
+
             ProcessStartInfo startInfo = new ProcessStartInfo
             {
                 WorkingDirectory = Settings.RootDir,
@@ -88,6 +93,13 @@ namespace OWASP.WebGoat.NET.App_Code
                     return 1;
                 }
             }
+        }
+
+        private static bool IsValidArgument(string args)
+        {
+            // Implement validation logic here. For example, allow only certain commands or arguments.
+            // This is a simple example that only allows alphanumeric arguments.
+            return System.Text.RegularExpressions.Regex.IsMatch(args, @"^[a-zA-Z0-9\s\-\/]+$");
         }
     }
 }


### PR DESCRIPTION
Fixes [https://github.com/tkopacz/fy25-advsec-demo-csharp/security/code-scanning/22](https://github.com/tkopacz/fy25-advsec-demo-csharp/security/code-scanning/22)

To fix the problem, we need to ensure that the `args` parameter is sanitized or validated before being used in `ProcessStartInfo.Arguments`. One way to achieve this is by using a whitelist approach, where only known safe commands and arguments are allowed. Alternatively, we can escape any potentially dangerous characters in the `args` parameter.

The best way to fix this without changing existing functionality is to introduce a method that validates the `args` parameter against a whitelist of allowed commands and arguments. This method should be called before setting the `Arguments` property of `ProcessStartInfo`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
