### PR TITLE
Potential fix for code scanning alert no. 17: XPath injection

### DIFF
--- a/WebGoat/Content/XPathInjection.aspx.cs
+++ b/WebGoat/Content/XPathInjection.aspx.cs
@@ -6,7 +6,7 @@ using System.Web.UI;
 using System.Web.UI.WebControls;
 using System.Xml;
 using System.Xml.XPath;
-
+using System.Xml.Xsl;
 namespace OWASP.WebGoat.NET
 {
     public partial class XPathInjection : System.Web.UI.Page
@@ -25,13 +25,58 @@ namespace OWASP.WebGoat.NET
         {
             XmlDocument xDoc = new XmlDocument();
             xDoc.LoadXml(xml);
-            XmlNodeList list = xDoc.SelectNodes("//salesperson[state='" + state + "']");
-            if (list.Count > 0)
-            {
 
+            // Create an XPathNavigator for querying with variables
+            XPathNavigator nav = xDoc.CreateNavigator();
+            string xpath = "//salesperson[state=$state]";
+            XPathExpression expr = nav.Compile(xpath);
+
+            // Prepare argument list with the user-supplied value
+            XsltArgumentList varList = new XsltArgumentList();
+            varList.AddParam("state", string.Empty, state);
+
+            // Set the expression context using our custom context for variable resolution
+            expr.SetContext(new VariableContext(varList));
+
+            XPathNodeIterator iterator = nav.Select(expr);
+            // Collect nodes in a list for compatibility with previous logic
+            List<XPathNavigator> nodes = new List<XPathNavigator>();
+            while (iterator.MoveNext())
+            {
+                nodes.Add(iterator.Current.Clone());
             }
 
+            if (nodes.Count > 0)
+            {
+                // (processing logic can be added here)
+            }
         }
     }
-}
 
+    // Custom XsltContext for variable resolution
+    public class VariableContext : XsltContext
+    {
+        private XsltArgumentList _args;
+        public VariableContext(XsltArgumentList args) : base() { _args = args; }
+        public override IXsltContextVariable ResolveVariable(string prefix, string name)
+        {
+            object value = _args.GetParam(name, string.Empty) ?? string.Empty;
+            return new XsltContextVariableImpl(value);
+        }
+        // Unused in this context
+        public override bool Whitespace => false;
+        public override int CompareDocument(string baseUri, string nextbaseUri) => 0;
+        public override bool PreserveWhitespace(XPathNavigator node) => false;
+        public override IXsltContextFunction ResolveFunction(string prefix, string name, XPathResultType[] ArgTypes) => null;
+    }
+    // Helper for returning variable values
+    public class XsltContextVariableImpl : IXsltContextVariable
+    {
+        private object _value;
+        public XsltContextVariableImpl(object value) { _value = value; }
+        public bool IsLocal => false;
+        public bool IsParam => true;
+        public XPathResultType VariableType => XPathResultType.Any;
+        public object Evaluate(XsltContext xsltContext) => _value;
+    }
+}


### PR DESCRIPTION
Potential fix for [https://github.com/tkopacz/fy25-advsec-demo-csharp/security/code-scanning/17](https://github.com/tkopacz/fy25-advsec-demo-csharp/security/code-scanning/17)

To fix this XPath injection vulnerability, the code should avoid inserting raw user input directly into the XPath expression. Instead, it should compile the XPath query using variables and supply user input securely as a parameter. This can be accomplished by:

- Updating the XPath expression to use a variable (e.g., `$state`) in place of direct concatenation,
- Compiling the XPath expression using `XPathExpression.Compile()`,
- Creating an `XsltArgumentList` and adding the user-provided value as a parameter,
- Supplying the arguments through a custom `XsltContext` subclass (such as `System.Xml.Xsl.XsltContext`), implementing variable resolution to retrieve the value from the argument list,
- Using this context with `XPathExpression.SetContext()` before running the query.

Because .NET does not have direct first-class XPath variable support in `XmlDocument.SelectNodes`, we need to use the lower-level `XPathNavigator`, which supports the evaluation of compiled expressions with variable references and context.

This will all be within the `FindSalesPerson` method in `WebGoat/Content/XPathInjection.aspx.cs`. We'll also need to add a custom `XsltContext` and definitions to support variable injection.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
